### PR TITLE
Add indexgap

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,8 +2016,8 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
-- name: indexgap
-  github_id: borisowlexa2010-star/IndexGap
-  pypi_id: indexgap
-  category: web-dev
-  description: Lint your programmatic SEO pipeline — from keywords to indexed pages. No dependencies.
+  - name: indexgap
+    github_id: borisowlexa2010-star/IndexGap
+    pypi_id: indexgap
+    category: web-dev
+    description: "Lint your programmatic SEO pipeline — from keywords to indexed pages. No dependencies."

--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,3 +2016,8 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+- name: indexgap
+  github_id: borisowlexa2010-star/IndexGap
+  pypi_id: indexgap
+  category: web-dev
+  description: Lint your programmatic SEO pipeline — from keywords to indexed pages. No dependencies.


### PR DESCRIPTION
indexgap is a CLI that audits programmatic SEO pipelines: it fact-checks the numbers on generated pages against the dataset row that produced each page, collapses template-wide findings into one work order, clusters near-duplicates, and validates hreflang across language versions.

Python 3.9+, standard library only — zero dependencies. On PyPI as `indexgap`. MIT. Docs: https://borisowlexa2010-star.github.io/IndexGap/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `indexgap` to the projects list so it appears in the directory. The entry records its GitHub and PyPI IDs, category, and a short description, and is indented under `projects:` so it is recognized.

<sup>Written for commit 42841a45cd3841da9b1dd70063b41bf40515418e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

